### PR TITLE
Allow cancel of request

### DIFF
--- a/xolphin/endpoint/request.py
+++ b/xolphin/endpoint/request.py
@@ -69,6 +69,11 @@ class Request(object):
         return Base(self.client.post('requests/%d/notes' % id, {
             'message': message
         }))
+    
+    def cancel(self, id, reason):
+        return Base(self.client.post('requests/%d/cancel' % id, {
+            'reason': reason
+        }))    
 
     def get_notes(self, id):
         notes = []


### PR DESCRIPTION
Allows cancel of request via request method instead of using client.post()